### PR TITLE
Join game and create game buttons disabled

### DIFF
--- a/src/public/lobby.js
+++ b/src/public/lobby.js
@@ -72,24 +72,17 @@ socket.on('get_game_id', (gameID) => {
   window.location.href = '/game/play'
 })
 
-/*
-// When the user clicks the create game button and the game is standard, the server is sent the details of the game. If it is happy,
-// it will create an unique game ID that will be received here.
-socket.on('get_game_id_reg_game', (gameID) => {
-    sessionStorage.setItem('gameID', gameID)
-    sessionStorage.setItem('gameType', 'regular')
-    window.location.href = `/game/play`
-})
+function joinRunningGame (event) {
+  // Let's disable all the buttons so that the user can't try joining multiple games while
+  // the db is being queried.
+  $('#gameInfoTableBody').find('button').attr('disabled', 'disabled')
 
-// When the user clicks the create game button and the game is custom, the server is sent the details of the game. If it is happy,
-// it will create an unique game ID that will be received here.
-socket.on('get_game_id_custom_game', (gameID) => {
-    sessionStorage.setItem('gameID', gameID)
-    sessionStorage.setItem('gameType', 'custom')
-    window.location.href = `/game/play`
-}) */
+  // Add a loading icon to the button
+  document.getElementById(event.target.id).innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span><span class="sr-only">Joining...</span>'
 
-function joinRunningGame () {
+  // Let's also disable the create game button since the user is already joining a game.
+  $('#createGameBtn').attr('disabled', 'disabled')
+
   sessionStorage.setItem('gameID', this.id)
   window.location.href = '/game/play'
 }
@@ -120,13 +113,4 @@ document.getElementById('createGameBtn').addEventListener('click', () => {
 
   socket.connect()
   socket.emit('create_game', numPlayers, modeChosen, document.getElementById('customWord').value)
-  /*
-    // Creates the game in the database
-    request.open('POST', '/lobby/create', true)
-    request.setRequestHeader('Content-type', 'application/json')
-    request.send(JSON.stringify({ numPlayers: $("#numPlayers").val() , customWord: document.getElementById('customWord').value, gameMode: modeChosen}))
-
-    socket.connect()
-    socket.emit('create_game', gameType, numPlayers)
-    */
 })

--- a/src/public/lobby.js
+++ b/src/public/lobby.js
@@ -111,6 +111,15 @@ document.getElementById('createGameBtn').addEventListener('click', () => {
     }
   }
 
+  // Disable the create game button before sending the request to the server.
+  $('#createGameBtn').attr('disabled', 'disabled')
+
+  // Add a loading icon
+  document.getElementById('createGameBtn').innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span><span class="sr-only">Creating game...</span>'
+
+  // Disable the join game buttons for existing games.
+  $('#gameInfoTableBody').find('button').attr('disabled', 'disabled')
+
   socket.connect()
   socket.emit('create_game', numPlayers, modeChosen, document.getElementById('customWord').value)
 })


### PR DESCRIPTION
# Description
Join buttons and create game button are now disabled when a user joins an existing game. This is done since a little bit of time is needed for the server to query the db and add the player to the relevant table.
Similarly, when a user clicks the create game button, the join existing game buttons are disabled while the new game is being created.
