### PR TITLE
"Word contains invalid characters" bug fix

### DIFF
--- a/src/services/lobby.cjs
+++ b/src/services/lobby.cjs
@@ -142,11 +142,13 @@ async function getGameGuesses (gameID) {
 }
 
 async function isGuessAWord (word) {
-  const sqlCode = `SELECT * FROM [dbo].[Vocabulary]
-  WHERE Word = '${word.toLowerCase()}'`
-
   return new Promise((resolve, reject) => {
-    if (/^[a-zA-Z]+$/.test(word.toLowerCase()) === true && word.length === 5) {
+    const wordTrimmed = word.toLowerCase().substring(0, 5)
+
+    const sqlCode = `SELECT * FROM [dbo].[Vocabulary]
+  WHERE Word = '${wordTrimmed}'`
+
+    if (/^[a-zA-Z]+$/.test(wordTrimmed) === true) {
       get('default').then(
         (pool) => pool.request().query(sqlCode).then(
           (result) => {


### PR DESCRIPTION
# Description
In the event that a word longer than five characters is sent to the server, only the first five letters are used.

Fixes issue described in #132.
